### PR TITLE
Use github context to name the docker hub

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -12,9 +12,6 @@ name: Publish Docker image
 on:
   release:
     types: [published]
-env:
-  DOCKER_HUB_NAMESPACE: serroba
-  DOCKER_HUB_REPOSITORY: pymodbus
 
 jobs:
   push_to_registry:
@@ -42,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.DOCKER_HUB_REPOSITORY }}
+          images: ${{ github.repository }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v3


### PR DESCRIPTION
Use github context to name the docker hub

Previously, I was using a hardcoded value instead of the github context variable